### PR TITLE
fix: remove duplicate capitalized Ai.meta.com entry

### DIFF
--- a/meta-adblock.txt
+++ b/meta-adblock.txt
@@ -10337,7 +10337,6 @@
 ||aime8.i.org^
 ||ai.messenger.com^
 ||ai.meta.com^
-||Ai.meta.com^
 ||aiminternet.facebook.com^
 ||aim.messenger.com^
 ||aimmxtest7.accountkit.com^

--- a/meta-dnsmasq.txt
+++ b/meta-dnsmasq.txt
@@ -10337,7 +10337,6 @@ local=/aimagelab.m.facebook.com/
 local=/aime8.i.org/
 local=/ai.messenger.com/
 local=/ai.meta.com/
-local=/Ai.meta.com/
 local=/aiminternet.facebook.com/
 local=/aim.messenger.com/
 local=/aimmxtest7.accountkit.com/

--- a/meta-domains.txt
+++ b/meta-domains.txt
@@ -10336,7 +10336,6 @@ aimagelab.m.facebook.com
 aime8.i.org
 ai.messenger.com
 ai.meta.com
-Ai.meta.com
 aiminternet.facebook.com
 aim.messenger.com
 aimmxtest7.accountkit.com

--- a/meta-hosts_4+6.txt
+++ b/meta-hosts_4+6.txt
@@ -20666,8 +20666,6 @@
 :: ai.messenger.com
 0.0.0.0 ai.meta.com
 :: ai.meta.com
-0.0.0.0 Ai.meta.com
-:: Ai.meta.com
 0.0.0.0 aiminternet.facebook.com
 :: aiminternet.facebook.com
 0.0.0.0 aim.messenger.com

--- a/meta-hosts_4.txt
+++ b/meta-hosts_4.txt
@@ -10336,7 +10336,6 @@
 0.0.0.0 aime8.i.org
 0.0.0.0 ai.messenger.com
 0.0.0.0 ai.meta.com
-0.0.0.0 Ai.meta.com
 0.0.0.0 aiminternet.facebook.com
 0.0.0.0 aim.messenger.com
 0.0.0.0 aimmxtest7.accountkit.com

--- a/meta-unbound.txt
+++ b/meta-unbound.txt
@@ -10336,7 +10336,6 @@ local-zone: "aimagelab.m.facebook.com" always_refuse
 local-zone: "aime8.i.org" always_refuse
 local-zone: "ai.messenger.com" always_refuse
 local-zone: "ai.meta.com" always_refuse
-local-zone: "Ai.meta.com" always_refuse
 local-zone: "aiminternet.facebook.com" always_refuse
 local-zone: "aim.messenger.com" always_refuse
 local-zone: "aimmxtest7.accountkit.com" always_refuse


### PR DESCRIPTION
## Summary
Remove capitalized `Ai.meta.com` from the blocklist since DNS is case-insensitive — `ai.meta.com` (lowercase) already exists on line 10338.

## Fix
- Deleted: `Ai.meta.com` (line 10339)
- Retained: `ai.meta.com` (line 10338)

## Why
DNS domain names are case-insensitive. Having both `ai.meta.com` and `Ai.meta.com` as separate entries is redundant. All other entries in `meta-domains.txt` use lowercase.

Fixes issue #5.